### PR TITLE
chore: replace GitHub dependabot reviewers with codeowners (INTERN-68)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub Actions files
+/.github/               @skriptfabrik/github-actions-maintainers
+
+# Docker files
+Dockerfile              @skriptfabrik/docker-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,10 @@ version: 2
 updates:
   - package-ecosystem: 'docker'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/docker-maintainers'
     schedule:
       interval: 'weekly'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/github-actions-maintainers'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
This pull request will replace the retiring dependabot reviewers configuration with CODEOWNERS.